### PR TITLE
Focus fix

### DIFF
--- a/addon/services/component-focus/focus-manager.js
+++ b/addon/services/component-focus/focus-manager.js
@@ -23,13 +23,20 @@ export default Ember.Service.extend({
 
   focusComponent(component, child = null) {
     let el = findElToFocus(component, child);
+    let isFocusable = el.hasAttribute('tabindex') || isDefaultFocusable(el);
 
-    if (!el.hasAttribute('tabindex') && !isDefaultFocusable(el)) {
+    if (!isFocusable) {
       el.setAttribute('tabindex', -1);
-      this.set('_nextToReset', el);
     }
 
     el.focus();
+
+    // Done after `el.focus()` to prevent the `blur` handler from triggering
+    // too early.
+    if (!isFocusable) {
+      this.set('_nextToReset', el);
+    }
+
     return el;
   },
 
@@ -83,9 +90,9 @@ export default Ember.Service.extend({
     }
   },
 
-  _handleBlur(e) {
+  _handleBlur() {
     let elToReset = this.get('_nextToReset');
-    if (elToReset && e.target === elToReset) {
+    if (elToReset) {
       elToReset.removeAttribute('tabindex');
       this.set('_nextToReset', null);
     }

--- a/addon/services/component-focus/focus-manager.js
+++ b/addon/services/component-focus/focus-manager.js
@@ -83,9 +83,9 @@ export default Ember.Service.extend({
     }
   },
 
-  _handleBlur() {
+  _handleBlur(e) {
     let elToReset = this.get('_nextToReset');
-    if (elToReset) {
+    if (elToReset && e.target === elToReset) {
       elToReset.removeAttribute('tabindex');
       this.set('_nextToReset', null);
     }

--- a/tests/unit/services/component-focus/focus-manager-test.js
+++ b/tests/unit/services/component-focus/focus-manager-test.js
@@ -98,6 +98,8 @@ test('focusComponent() can focus on a new element when another element has focus
 
   service.focusComponent(component, spanEl);
   assert.equal(document.activeElement, spanEl, 'The focus component did not focus properly');
+
+  document.body.removeChild(focusEl);
 });
 
 test('focusComponent() does not change tabindex on a child that already has it', function(assert) {

--- a/tests/unit/services/component-focus/focus-manager-test.js
+++ b/tests/unit/services/component-focus/focus-manager-test.js
@@ -157,7 +157,7 @@ test('focusComponentAfterRender() returns a promise that is resolved with the fo
 });
 
 test('focusComponentAfterRender() only calls focusComponent() for the last request', function(assert) {
-  assert.expect();
+  assert.expect(2);
   run(() => {
     service.focusComponentAfterRender(component, inputEl);
     service.focusComponentAfterRender(component, spanEl);

--- a/tests/unit/services/component-focus/focus-manager-test.js
+++ b/tests/unit/services/component-focus/focus-manager-test.js
@@ -87,6 +87,19 @@ test('focusComponent() will register the child to be reset on blur if it sets ta
   assert.notOk(spanEl.hasAttribute('tabindex'));
 });
 
+test('focusComponent() can focus on a new element when another element has focus first', function(assert) {
+  assert.expect(2);
+
+  // create element to focus on first
+  var focusEl = document.createElement('button');
+  document.body.appendChild(focusEl);
+  focusEl.focus();
+  assert.equal(document.activeElement, focusEl, 'A new element could not be focused on');
+
+  service.focusComponent(component, spanEl);
+  assert.equal(document.activeElement, spanEl, 'The focus component did not focus properly');
+});
+
 test('focusComponent() does not change tabindex on a child that already has it', function(assert) {
   assert.expect(1);
   spanEl.setAttribute('tabindex', 0);


### PR DESCRIPTION
I encountered a bug where I had a clickable component, which, when clicked, should have focused on a `<div>`. However, it wasn't focusing for some reason. I believe that the `<div>` wasn't being focused because the blur handler doesn't check which element is blurred, so it removes the `tabindex="-1"` that this addon adds right before. The simple fix is just to move `el.focus()` before we set `_nextToReset` to prevent the blur handler from prematurely triggering.
