### PR TITLE
Add call to _super in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ export default Ember.Component.extend(FocusableComponent, {
   // ...
 
   didInsertElement() {
+    this._super(...arguments);
     this.focus();
   },
 


### PR DESCRIPTION
This is a common problem I see new ember developers making so, if they copy-paste this example from the README, let's not lead them astray.